### PR TITLE
Replace branding mentrions to `Console` with `Hosting`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 <p align="center">
-  <a href="https://console.amplify.aws">
+  <a href="https://aws.amazon.com/amplify/hosting/">
     <img alt="Amplify" src="https://github.com/aws-amplify/community/blob/master/src/assets/images/logo-dark.png" width="60" />
   </a>
 </p>
 <h1 align="center">
-  Amplify Console
+  Amplify Hosting
 </h1>
 
 [![DiscordChat](https://img.shields.io/discord/308323056592486420?logo=discord")](https://discord.gg/jWVbPfC)
 
-The AWS Amplify Console provides a Git-based workflow for deploying and hosting fullstack serverless web applications. This repository provides:
+AWS Amplify Hosting provides a Git-based workflow for deploying and hosting fullstack serverless web applications. This repository provides:
 
-- A [FAQ](https://github.com/aws-amplify/amplify-console/blob/master/FAQ.md) for common issues
-- [Release history](https://github.com/aws-amplify/amplify-console/blob/master/CHANGELOG.md)
-- Tools and [build images](https://github.com/aws-amplify/amplify-console/tree/master/images)
+- A [FAQ](https://github.com/aws-amplify/amplify-hosting/blob/master/FAQ.md) for common issues
+- [Release history](https://github.com/aws-amplify/amplify-hosting/blob/master/CHANGELOG.md)
+- Tools and [build images](https://github.com/aws-amplify/amplify-hosting/tree/master/images)
 - RFCs for new feature launches
-- [Issue tracking](https://github.com/aws-amplify/amplify-console/issues) - we also maintain an [AWS Forum](https://forums.aws.amazon.com/forum.jspa?forumID=314) but use this GitHub repository as our primary issue tracker.
+- [Issue tracking](https://github.com/aws-amplify/amplify-hosting/issues) - we also maintain an [AWS Forum](https://forums.aws.amazon.com/forum.jspa?forumID=314) but use this GitHub repository as our primary issue tracker.
 
-### Report a bug 🐛or feature request 💡[here](https://github.com/aws-amplify/amplify-console/issues/new/choose)
+### Report a bug 🐛or feature request 💡[here](https://github.com/aws-amplify/amplify-hosting/issues/new/choose)
 
 ### Bookmarks
 


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
