### PR TITLE
feat(workflow): close stale issues

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,0 +1,45 @@
+name: "Close Stale Issues"
+
+# Controls when the action will run.
+on:
+  schedule:
+    - cron: "0 */1 * * *"
+
+jobs:
+  cleanup:
+    permissions:
+      issues: write
+      contents: read
+    runs-on: ubuntu-latest
+    name: Stale issue job
+    steps:
+      - uses: aws-actions/stale-issue-cleanup@v3
+        with:
+          # Setting messages to an empty string will cause the automation to skip that category.
+          stale-issue-message: This issue has not received a response in a while. If you want to keep this issue open, please leave a comment below and auto-close will be canceled.
+          # ancient-issue-message: ''
+          # stale-pr-message: ''
+
+          # These labels are required
+          stale-issue-label: closing-soon
+          exempt-issue-labels: no-autoclose
+          response-requested-label: response-requested
+          # stale-pr-label: closing-soon
+          # exempt-pr-labels: no-autoclose
+
+          # Don't set closed-for-staleness label to skip closing very old issues regardless of label.
+          closed-for-staleness-label: closed-for-staleness
+
+          # Issue timing
+          days-before-stale: 3
+          days-before-close: 4
+          # An "upvote" is the total number of +1, heart, hooray, and rocket reactions on an issue.
+          minimum-upvotes-to-exempt: 5
+          # days-before-ancient: 365
+
+          # Testing/debugging options
+          loglevel: DEBUG
+          # Set dry-run to true to not perform label or close actions.
+          dry-run: false
+
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### Description of changes

This PR will introduce a GitHub workflow to automate the closure of stale issues on the Amplify Hosting repository:
- Assign the `response-requested` label to an issue, this will trigger the workflow
- 3 days later if there is no activity on the issue, a `closing-soon` label will be attached to the issue and the requester will be notified with the following comment:
```
This issue has not received a response in a while. If you want to keep this issue open, please leave a comment below and auto-close will be canceled.
```
- 4 days after the above comment if there continues to be no activity on the issue, the issue will be closed with a `closed-for-staleness` label.
- The issue can be exempted from auto-closing in the following scenarios:
   - if there is any activity on the issue, the `closing-soon` and `response-requested` labels will be removed
   - `no-autoclose` label is attached to the issue
   - issue has gained traction via up-votes i.e. 👍 ❤️ 🚀 🎉  (minimum 5 upvotes required)  


#### Checklist

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
