### PR TITLE
feat(workflow): new issue notifier

### DIFF
--- a/.github/workflows/new-issue-notifier.yml
+++ b/.github/workflows/new-issue-notifier.yml
@@ -1,0 +1,20 @@
+name: Notify New Issues
+
+on:
+  issues:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      # Runs a single command using the runners shell
+      - name: Run webhook curl command
+        env:
+          WEBHOOK_URL: ${{ secrets.SLACK_ISSUE_WEBHOOK_URL }}
+          # GITHUB_CONTEXT: ${{toJson(github)}}
+          ISSUE: ${{toJson(github.event.issue.title)}}
+        shell: bash
+        run: echo $ISSUE | sed 's/[^a-zA-Z0-9 &().,:]//g' | xargs -I {} curl -s POST "$WEBHOOK_URL" -H "Content-Type:application/json" --data '{"issue":"{}", "issueTitle":"${{github.event.issue.title}}", "issueUrl":"${{github.event.issue.html_url}}", "issueAuthor":"${{github.event.issue.user.login}}", "issueNumber":"${{github.event.issue.number}}", "issueCreateTime":"${{github.event.issue.created_at}}"}'


### PR DESCRIPTION
#### Description of changes

This PR will introduce a GitHub workflow which will send a notification to an internal Slack channel when a new GitHub issue is created within the Amplify Hosting GitHub repository.

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
