### PR TITLE
feat(workflow): lock issues

### DIFF
--- a/.github/workflows/lock-issues.yml
+++ b/.github/workflows/lock-issues.yml
@@ -1,0 +1,51 @@
+name: "Lock Issues"
+
+on:
+  schedule:
+    - cron: "0 */1 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: lock
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v3
+        with:
+          github-token: ${{ github.token }}
+          issue-inactive-days: "0"
+          exclude-issue-created-before: ""
+          exclude-issue-created-after: ""
+          exclude-issue-created-between: ""
+          exclude-issue-closed-before: ""
+          exclude-issue-closed-after: ""
+          exclude-issue-closed-between: ""
+          include-any-issue-labels: ""
+          include-all-issue-labels: ""
+          exclude-any-issue-labels: ""
+          add-issue-labels: "archived"
+          remove-issue-labels: ""
+          issue-comment: "This issue has been automatically locked since there has not been any recent activity after it was closed. Please open a new issue for related bugs."
+          issue-lock-reason: ""
+          pr-inactive-days: "0"
+          exclude-pr-created-before: ""
+          exclude-pr-created-after: ""
+          exclude-pr-created-between: ""
+          exclude-pr-closed-before: ""
+          exclude-pr-closed-after: ""
+          exclude-pr-closed-between: ""
+          include-any-pr-labels: ""
+          include-all-pr-labels: ""
+          exclude-any-pr-labels: ""
+          add-pr-labels: ""
+          remove-pr-labels: ""
+          pr-comment: ""
+          pr-lock-reason: ""
+          process-only: "issues"
+          log-output: false


### PR DESCRIPTION
#### Description of changes

This PR will introduce a GitHub workflow to lock issues immediately after they are closed with the following comment and an `archived` label:
```
This issue has been automatically locked since there has not been any recent activity after it was closed. Please open a new issue for related bugs.
```
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
