### PR TITLE
feat: add node 18 to dockerfile

### DIFF
--- a/images/latest/Dockerfile
+++ b/images/latest/Dockerfile
@@ -10,6 +10,7 @@ ENV VERSION_NODE_12=12
 ENV VERSION_NODE_14=14
 ENV VERSION_NODE_16=16
 ENV VERSION_NODE_17=17
+ENV VERSION_NODE_18=18
 ENV VERSION_NODE_DEFAULT=$VERSION_NODE_14
 ENV VERSION_RUBY_2_4=2.4.6
 ENV VERSION_RUBY_2_6=2.6.3
@@ -132,6 +133,9 @@ RUN /bin/bash -c ". ~/.nvm/nvm.sh && \
     npm install -g yarn@${VERSION_YARN} sm@${VERSION_SM} grunt-cli@${VERSION_GRUNT_CLI} bower@${VERSION_BOWER} vuepress@${VERSION_VUEPRESS} && \
     npm install -g --unsafe-perm=true gatsby-cli@${VERSION_GATSBY_CLI} && \
     nvm install $VERSION_NODE_17 && nvm use $VERSION_NODE_17 && chown -R root:root /root/.nvm && \
+    npm install -g yarn@${VERSION_YARN} sm@${VERSION_SM} grunt-cli@${VERSION_GRUNT_CLI} bower@${VERSION_BOWER} vuepress@${VERSION_VUEPRESS} && \
+    npm install -g --unsafe-perm=true gatsby-cli@${VERSION_GATSBY_CLI} && \
+    nvm install $VERSION_NODE_18 && nvm use $VERSION_NODE_18 && chown -R root:root /root/.nvm && \
     npm install -g yarn@${VERSION_YARN} sm@${VERSION_SM} grunt-cli@${VERSION_GRUNT_CLI} bower@${VERSION_BOWER} vuepress@${VERSION_VUEPRESS} && \
     npm install -g --unsafe-perm=true gatsby-cli@${VERSION_GATSBY_CLI} && \
     nvm alias default ${VERSION_NODE_DEFAULT} && nvm cache clear"


### PR DESCRIPTION


#### Description of changes

[Node 16 is now no longer on LTS, LTS is now version 18.
](https://github.com/nodejs/release#release-schedule)
I added Node v18 to the list of supported/preinstalled versions within nvm

#### Issue #, if available

None

#### Checklist

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
