### PR TITLE
Use Hugo extended instead of Hugo

### DIFF
--- a/images/latest/Dockerfile
+++ b/images/latest/Dockerfile
@@ -87,10 +87,10 @@ RUN yum -y update && \
     rm -rf /var/cache/yum
 
 ## Install Hugo
-RUN wget https://github.com/gohugoio/hugo/releases/download/v${VERSION_HUGO}/hugo_${VERSION_HUGO}_Linux-64bit.tar.gz && \
-    tar -xf hugo_${VERSION_HUGO}_Linux-64bit.tar.gz hugo -C / && \
+RUN wget https://github.com/gohugoio/hugo/releases/download/v${VERSION_HUGO}/hugo_extended_${VERSION_HUGO}_Linux-64bit.tar.gz && \
+    tar -xf hugo_extended_${VERSION_HUGO}_Linux-64bit.tar.gz hugo -C / && \
     mv /hugo /usr/bin/hugo && \
-    rm -rf hugo_${VERSION_HUGO}_Linux-64bit.tar.gz
+    rm -rf hugo_extended_${VERSION_HUGO}_Linux-64bit.tar.gz
 
 ## Install dotnet sdk and host 3.1
 RUN rpm -Uvh https://packages.microsoft.com/config/centos/7/packages-microsoft-prod.rpm


### PR DESCRIPTION
#### Description of changes

Use Hugo extended instead of Hugo

(not sure if modifying this Dockerfile actually changes the way Amplify downloads Hugo :man_shrugging:)

#### Issue #, if available

#884

#### Checklist


- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
