### PR TITLE
docs(faq):ssm param errors

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -13,7 +13,7 @@
   - [New commits are not triggering builds on Amplify](#new-commits-are-not-triggering-builds-on-amplify)
   - [I do not see my repo in the list](#i-do-not-see-my-repo-in-the-list)
   - [Build fails with _Cannot find module aws-exports_](#build-fails-with-cannot-find-module-aws-exports)
-  - [Preview build fails with _SSM parameter errors_](#preview-build-fails-with-ssm-parameter-errors)
+  - [Build fails with _SSM parameter errors_](#build-fails-with-ssm-parameter-errors)
   - [How do I override a build timeout?](#how-do-i-override-a-build-timeout)
   - [How do I pull private packages during a build?](#how-do-i-pull-private-packages-during-a-build)
   - [How do I run Amplify functions with Python runtime?](#how-do-i-run-amplify-functions-with-python-runtime)
@@ -76,12 +76,12 @@ backend:
         - "# Execute Amplify CLI with the helper script"
         - amplifyPush --simple
 ```
-### Preview build fails with _SSM parameter errors_
+### Build fails with _SSM parameter errors_
 
-Amplify CLI version 11 started using Parameter Store from AWS Systems Manager (SSM). In case of preview builds, you would now have to ensure that certain values like Imported backend resources (Storage/Auth) details or Lambda function environment variables have corresponding SSM paramters created manually. You might observe the following errors in this scenario -
+Amplify CLI version 11 started using Parameter Store from AWS Systems Manager (SSM). A sucessful Amplify CLI push performed locally will create the required SSM parameters. However, in case of preview builds or builds where backend is directly pushed through Amplify Hosting, you would need to ensure that certain values for Imported backend resources (Storage/Auth) details or Lambda function environment variables should have corresponding SSM paramters created manually. You might observe the following errors in this scenario
 
 1. `This environment is missing some parameter values` - You can refer the documentation [here](https://docs.amplify.aws/cli/reference/ssm-parameter-store/#manually-creating-parameters) for manually creating the required SSM parameters. 
-3. `Failed to download the following parameters from ParameterStore` - You need to ensure that the desired value is enclosed in quotes so that the value will be parsed using JSON.parse().
+2. `Failed to download the following parameters from ParameterStore` - You need to ensure that the desired value is enclosed in quotes so that the value will be parsed using JSON.parse().
 
 ### How do I override a build timeout?
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -13,6 +13,7 @@
   - [New commits are not triggering builds on Amplify](#new-commits-are-not-triggering-builds-on-amplify)
   - [I do not see my repo in the list](#i-do-not-see-my-repo-in-the-list)
   - [Build fails with _Cannot find module aws-exports_](#build-fails-with-cannot-find-module-aws-exports)
+  - [Preview build fails with _SSM parameter errors_](#preview-build-fails-with-ssm-parameter-errors)
   - [How do I override a build timeout?](#how-do-i-override-a-build-timeout)
   - [How do I pull private packages during a build?](#how-do-i-pull-private-packages-during-a-build)
   - [How do I run Amplify functions with Python runtime?](#how-do-i-run-amplify-functions-with-python-runtime)
@@ -75,6 +76,12 @@ backend:
         - "# Execute Amplify CLI with the helper script"
         - amplifyPush --simple
 ```
+### Preview build fails with _SSM parameter errors_
+
+Amplify CLI version 11 started using Parameter Store from AWS Systems Manager (SSM). In case of preview builds, you would now have to ensure that certain values like Imported backend resources (Storage/Auth) details or Lambda function environment variables have corresponding SSM paramters created manually. You might observe the following errors in this scenario -
+
+1. `This environment is missing some parameter values` - You can refer the documentation [here](https://docs.amplify.aws/cli/reference/ssm-parameter-store/#manually-creating-parameters) for manually creating the required SSM parameters. 
+3. `Failed to download the following parameters from ParameterStore` - You need to ensure that the desired value is enclosed in quotes so that the value will be parsed using JSON.parse().
 
 ### How do I override a build timeout?
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-hosting/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
Included an FAQ around the errors that we encounter with respect missing/invalid SSM parameters that Amplify CLI v11+ uses. 

#### Issue #, if available

Starting version 11 Amplify CLI will be using [Parameter Store from AWS Systems Manager (SSM)](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html). Earlier, it was not possible to deploy full-stack builds or PR Builds (as also seen in [#2706](https://github.com/aws-amplify/amplify-hosting/issues/2706), [#3474](https://github.com/aws-amplify/amplify-hosting/issues/3474), [#3478](https://github.com/aws-amplify/amplify-hosting/issues/3478)) which contained environment variables which are needed for imported categories like Storage or Auth as well as Lambda function environment variables.  However, with this new [launch](https://docs.amplify.aws/cli/reference/ssm-parameter-store/) it is possible and we see SSM parameter related errors in console backend builds for the same.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [✓] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.