### PR TITLE
Fix amplify push twice

### DIFF
--- a/scripts/amplifyPush.sh
+++ b/scripts/amplifyPush.sh
@@ -74,11 +74,11 @@ then
     ENV=${USER_BRANCH}
 fi
 
-# strip slashes, limit to 10 chars
-ENV=$(echo "${ENV}" | sed 's;\\;;g' | sed 's;\/;;g' | cut -c -10)
+# strip slashes and dashes, limit to 10 chars
+ENV=$(echo "${ENV}" | sed 's;\\;;g ; s;\/;;g ; s;-;;g' | cut -c -10)
 
 # Check valid environment name
-if [[ -z ${ENV} || "${ENV}" =~ [^a-zA-Z0-9\-]+ ]] ; then help_output ; fi
+if [[ -z ${ENV} || "${ENV}" =~ [^a-zA-Z0-9]+ ]] ; then help_output ; fi
 
 read -r -d 'END' AWSCONFIG << EOM
 {

--- a/scripts/amplifyPush.sh
+++ b/scripts/amplifyPush.sh
@@ -21,7 +21,7 @@ init_env () {
     if [[ -z ${STACKINFO} ]];
     then
         echo "# Initializing new Amplify environment: ${ENV} (amplify init)"
-        [[ -z ${CATEGORIES} ]] && amplify init --amplify ${AMPLIFY} --providers ${PROVIDERS} --codegen ${CODEGEN} --yes --forcePush || amplify init --amplify ${AMPLIFY} --providers ${PROVIDERS} --codegen ${CODEGEN} --categories ${CATEGORIES} --yes --forcePush
+        if [[ -z ${CATEGORIES} ]]; then amplify init --amplify ${AMPLIFY} --providers ${PROVIDERS} --codegen ${CODEGEN} --yes --forcePush; else amplify init --amplify ${AMPLIFY} --providers ${PROVIDERS} --codegen ${CODEGEN} --categories ${CATEGORIES} --yes --forcePush; fi
         echo "# Environment ${ENV} details:"
         amplify env get --name ${ENV}
     else
@@ -29,7 +29,7 @@ init_env () {
         echo "# Importing Amplify environment: ${ENV} (amplify env import)"
         amplify env import --name ${ENV} --config "${STACKINFO}" --awsInfo ${AWSCONFIG} --yes;
         echo "# Initializing existing Amplify environment: ${ENV} (amplify init)"
-        [[ -z ${CATEGORIES} ]] && amplify init --amplify ${AMPLIFY} --providers ${PROVIDERS} --codegen ${CODEGEN} --yes --forcePush || amplify init --amplify ${AMPLIFY} --providers ${PROVIDERS} --codegen ${CODEGEN} --categories ${CATEGORIES} --yes --forcePush
+        if [[ -z ${CATEGORIES} ]]; then amplify init --amplify ${AMPLIFY} --providers ${PROVIDERS} --codegen ${CODEGEN} --yes --forcePush; else amplify init --amplify ${AMPLIFY} --providers ${PROVIDERS} --codegen ${CODEGEN} --categories ${CATEGORIES} --yes --forcePush; fi
         echo "# Environment ${ENV} details:"
         amplify env get --name ${ENV}
     fi

--- a/scripts/amplifyPush.sh
+++ b/scripts/amplifyPush.sh
@@ -21,17 +21,17 @@ init_env () {
     if [[ -z ${STACKINFO} ]];
     then
         echo "# Initializing new Amplify environment: ${ENV} (amplify init)"
-        if [[ -z ${CATEGORIES} ]]; then amplify init --amplify ${AMPLIFY} --providers ${PROVIDERS} --codegen ${CODEGEN} --yes --forcePush; else amplify init --amplify ${AMPLIFY} --providers ${PROVIDERS} --codegen ${CODEGEN} --categories ${CATEGORIES} --yes --forcePush; fi
+        if [[ -z ${CATEGORIES} ]]; then amplify init --amplify "${AMPLIFY}" --providers "${PROVIDERS}" --codegen "${CODEGEN}" --yes --forcePush; else amplify init --amplify "${AMPLIFY}" --providers "${PROVIDERS}" --codegen "${CODEGEN}" --categories "${CATEGORIES}" --yes --forcePush; fi
         echo "# Environment ${ENV} details:"
-        amplify env get --name ${ENV}
+        amplify env get --name "${ENV}"
     else
-        echo "STACKINFO="${STACKINFO}
+        echo "STACKINFO=${STACKINFO}"
         echo "# Importing Amplify environment: ${ENV} (amplify env import)"
-        amplify env import --name ${ENV} --config "${STACKINFO}" --awsInfo ${AWSCONFIG} --yes;
+        amplify env import --name "${ENV}" --config "${STACKINFO}" --awsInfo "${AWSCONFIG}" --yes;
         echo "# Initializing existing Amplify environment: ${ENV} (amplify init)"
-        if [[ -z ${CATEGORIES} ]]; then amplify init --amplify ${AMPLIFY} --providers ${PROVIDERS} --codegen ${CODEGEN} --yes --forcePush; else amplify init --amplify ${AMPLIFY} --providers ${PROVIDERS} --codegen ${CODEGEN} --categories ${CATEGORIES} --yes --forcePush; fi
+        if [[ -z ${CATEGORIES} ]]; then amplify init --amplify "${AMPLIFY}" --providers "${PROVIDERS}" --codegen "${CODEGEN}" --yes --forcePush; else amplify init --amplify "${AMPLIFY}" --providers "${PROVIDERS}" --codegen "${CODEGEN}" --categories "${CATEGORIES}" --yes --forcePush; fi
         echo "# Environment ${ENV} details:"
-        amplify env get --name ${ENV}
+        amplify env get --name "${ENV}"
     fi
     echo "# Done initializing Amplify environment: ${ENV}"
 }
@@ -75,55 +75,68 @@ then
 fi
 
 # strip slashes, limit to 10 chars
-ENV=$(echo ${ENV} | sed 's;\\;;g' | sed 's;\/;;g' | cut -c -10)
+ENV=$(echo "${ENV}" | sed 's;\\;;g' | sed 's;\/;;g' | cut -c -10)
 
 # Check valid environment name
 if [[ -z ${ENV} || "${ENV}" =~ [^a-zA-Z0-9\-]+ ]] ; then help_output ; fi
 
-AWSCONFIG="{\
-\"configLevel\":\"project\",\
-\"useProfile\":true,\
-\"profileName\":\"default\",\
-\"AmplifyAppId\":\"${AWS_APP_ID}\"\
-}"
-AMPLIFY="{\
-\"envName\":\"${ENV}\",\
-\"appId\":\"${AWS_APP_ID}\"\
-}"
-PROVIDERS="{\
-\"awscloudformation\":${AWSCONFIG}\
-}"
-CODEGEN="{\
-\"generateCode\":false,\
-\"generateDocs\":false\
-}"
+read -r -d 'END' AWSCONFIG << EOM
+{
+  "configLevel":"project",
+  "useProfile":true,
+  "profileName":"default",
+  "AmplifyAppId":"${AWS_APP_ID}"
+}END
+EOM
+read -r -d 'END' AMPLIFY << EOM
+{
+  "envName":"${ENV}",
+  "appId":"${AWS_APP_ID}"
+}END
+EOM
+read -r -d 'END' PROVIDERS << EOM
+{
+  "awscloudformation":${AWSCONFIG}
+}END
+EOM
+read -r -d 'END' CODEGEN << EOM
+{
+  "generateCode":false,
+  "generateDocs":false
+}END
+EOM
 CATEGORIES=""
 if [[ -z ${AMPLIFY_FACEBOOK_CLIENT_ID} && -z ${AMPLIFY_GOOGLE_CLIENT_ID} && -z ${AMPLIFY_AMAZON_CLIENT_ID} ]]; then
     CATEGORIES=""
 else
-    AUTHCONFIG="{\
-    \"facebookAppIdUserPool\":\"${AMPLIFY_FACEBOOK_CLIENT_ID}\",\
-    \"facebookAppSecretUserPool\":\"${AMPLIFY_FACEBOOK_CLIENT_SECRET}\",\
-    \"googleAppIdUserPool\":\"${AMPLIFY_GOOGLE_CLIENT_ID}\",\
-    \"googleAppSecretUserPool\":\"${AMPLIFY_GOOGLE_CLIENT_SECRET}\",\
-    \"amazonAppIdUserPool\":\"${AMPLIFY_AMAZON_CLIENT_ID}\",\
-    \"amazonAppSecretUserPool\":\"${AMPLIFY_AMAZON_CLIENT_SECRET}\"\
-    }"
-    CATEGORIES="{\
-    \"auth\":$AUTHCONFIG\
-    }"
+    read -r -d 'END' AUTHCONFIG << EOM
+{
+  "facebookAppIdUserPool":"${AMPLIFY_FACEBOOK_CLIENT_ID}",
+  "facebookAppSecretUserPool":"${AMPLIFY_FACEBOOK_CLIENT_SECRET}",
+  "googleAppIdUserPool":"${AMPLIFY_GOOGLE_CLIENT_ID}",
+  "googleAppSecretUserPool":"${AMPLIFY_GOOGLE_CLIENT_SECRET}",
+  "amazonAppIdUserPool":"${AMPLIFY_AMAZON_CLIENT_ID}",
+  "amazonAppSecretUserPool":"${AMPLIFY_AMAZON_CLIENT_SECRET}"
+}END
+EOM
+    read -r -d 'END' CATEGORIES << EOM
+{
+  "auth":$AUTHCONFIG
+}END
+EOM
 fi
 # Handle old or new config file based on simple flag
 if [[ ${IS_SIMPLE} ]];
 then
     echo "# Getting Amplify CLI Cloud-Formation stack info from environment cache"
-    export STACKINFO="$(envCache --get stackInfo)"
-    init_env ${ENV} ${AMPLIFY} ${PROVIDERS} ${CODEGEN} ${AWSCONFIG} ${CATEGORIES}
+    STACKINFO="$(envCache --get stackInfo)"
+    export STACKINFO
+    init_env "${ENV}" "${AMPLIFY}" "${PROVIDERS}" "${CODEGEN}" "${AWSCONFIG}" "${CATEGORIES}"
     echo "# Store Amplify CLI Cloud-Formation stack info in environment cache"
-    STACKINFO="$(amplify env get --json --name ${ENV})"
-    envCache --set stackInfo ${STACKINFO}
-    echo "STACKINFO="${STACKINFO}
+    STACKINFO="$(amplify env get --json --name "${ENV}")"
+    envCache --set stackInfo "${STACKINFO}"
+    echo "STACKINFO=${STACKINFO}"
 else
     # old config file, above steps performed outside of this script
-    init_env ${ENV} ${AMPLIFY} ${PROVIDERS} ${CODEGEN} ${AWSCONFIG} ${CATEGORIES}
+    init_env "${ENV}" "${AMPLIFY}" "${PROVIDERS}" "${CODEGEN}" "${AWSCONFIG}" "${CATEGORIES}"
 fi

--- a/scripts/amplifyPush.sh
+++ b/scripts/amplifyPush.sh
@@ -1,1 +1,129 @@
-# This script has been deprecated. Please refer to https://docs.amplify.aws/cli/usage/headless/ to run headless scripts in your build system.
+#!/usr/bin/env bash
+set -e
+IFS='|'
+
+help_output () {
+    echo "usage: amplify-push <--environment|-e <name>> <--simple|-s>"
+    echo "  --environment  The name of the Amplify environment to use"
+    echo "  --simple  Optional simple flag auto-includes stack info from env cache"
+    exit 1
+}
+
+init_env () {
+    ENV=$1
+    AMPLIFY=$2
+    PROVIDERS=$3
+    CODEGEN=$4
+    AWSCONFIG=$5
+    CATEGORIES=$6
+
+    echo "# Start initializing Amplify environment: ${ENV}"
+    if [[ -z ${STACKINFO} ]];
+    then
+        echo "# Initializing new Amplify environment: ${ENV} (amplify init)"
+        [[ -z ${CATEGORIES} ]] && amplify init --amplify ${AMPLIFY} --providers ${PROVIDERS} --codegen ${CODEGEN} --yes || amplify init --amplify ${AMPLIFY} --providers ${PROVIDERS} --codegen ${CODEGEN} --categories ${CATEGORIES} --yes
+        echo "# Environment ${ENV} details:"
+        amplify env get --name ${ENV}
+    else
+        echo "STACKINFO="${STACKINFO}
+        echo "# Importing Amplify environment: ${ENV} (amplify env import)"
+        amplify env import --name ${ENV} --config "${STACKINFO}" --awsInfo ${AWSCONFIG} --yes;
+        echo "# Initializing existing Amplify environment: ${ENV} (amplify init)"
+        [[ -z ${CATEGORIES} ]] && amplify init --amplify ${AMPLIFY} --providers ${PROVIDERS} --codegen ${CODEGEN} --yes || amplify init --amplify ${AMPLIFY} --providers ${PROVIDERS} --codegen ${CODEGEN} --categories ${CATEGORIES} --yes
+        echo "# Environment ${ENV} details:"
+        amplify env get --name ${ENV}
+    fi
+    echo "# Done initializing Amplify environment: ${ENV}"
+}
+
+ENV=""
+IS_SIMPLE=false
+POSITIONAL=()
+while [[ $# -gt 0 ]]
+    do
+    key="$1"
+    case ${key} in
+        -e|--environment)
+        ENV=$2
+        shift
+        ;;
+        -r|--region)
+        REGION=$2
+        shift
+        ;;
+        -s|--simple)
+        IS_SIMPLE=true
+        shift
+        ;;
+        *)
+        POSITIONAL+=("$1")
+        shift
+        ;;
+    esac
+done
+set -- "${POSITIONAL[@]}"
+
+# if no provided environment name, use default env variable, then user override
+if [[ ${ENV} = "" ]];
+then
+    ENV=${AWS_BRANCH}
+fi
+
+if [[ ${USER_BRANCH} != "" ]];
+then
+    ENV=${USER_BRANCH}
+fi
+
+# strip slashes, limit to 10 chars
+ENV=$(echo ${ENV} | sed 's;\\;;g' | sed 's;\/;;g' | cut -c -10)
+
+# Check valid environment name
+if [[ -z ${ENV} || "${ENV}" =~ [^a-zA-Z0-9\-]+ ]] ; then help_output ; fi
+
+AWSCONFIG="{\
+\"configLevel\":\"project\",\
+\"useProfile\":true,\
+\"profileName\":\"default\",\
+\"AmplifyAppId\":\"${AWS_APP_ID}\"\
+}"
+AMPLIFY="{\
+\"envName\":\"${ENV}\",\
+\"appId\":\"${AWS_APP_ID}\"\
+}"
+PROVIDERS="{\
+\"awscloudformation\":${AWSCONFIG}\
+}"
+CODEGEN="{\
+\"generateCode\":false,\
+\"generateDocs\":false\
+}"
+CATEGORIES=""
+if [[ -z ${AMPLIFY_FACEBOOK_CLIENT_ID} && -z ${AMPLIFY_GOOGLE_CLIENT_ID} && -z ${AMPLIFY_AMAZON_CLIENT_ID} ]]; then
+    CATEGORIES=""
+else
+    AUTHCONFIG="{\
+    \"facebookAppIdUserPool\":\"${AMPLIFY_FACEBOOK_CLIENT_ID}\",\
+    \"facebookAppSecretUserPool\":\"${AMPLIFY_FACEBOOK_CLIENT_SECRET}\",\
+    \"googleAppIdUserPool\":\"${AMPLIFY_GOOGLE_CLIENT_ID}\",\
+    \"googleAppSecretUserPool\":\"${AMPLIFY_GOOGLE_CLIENT_SECRET}\",\
+    \"amazonAppIdUserPool\":\"${AMPLIFY_AMAZON_CLIENT_ID}\",\
+    \"amazonAppSecretUserPool\":\"${AMPLIFY_AMAZON_CLIENT_SECRET}\"\
+    }"
+    CATEGORIES="{\
+    \"auth\":$AUTHCONFIG\
+    }"
+fi
+# Handle old or new config file based on simple flag
+if [[ ${IS_SIMPLE} ]];
+then
+    echo "# Getting Amplify CLI Cloud-Formation stack info from environment cache"
+    export STACKINFO="$(envCache --get stackInfo)"
+    init_env ${ENV} ${AMPLIFY} ${PROVIDERS} ${CODEGEN} ${AWSCONFIG} ${CATEGORIES}
+    echo "# Store Amplify CLI Cloud-Formation stack info in environment cache"
+    STACKINFO="$(amplify env get --json --name ${ENV})"
+    envCache --set stackInfo ${STACKINFO}
+    echo "STACKINFO="${STACKINFO}
+else
+    # old config file, above steps performed outside of this script
+    init_env ${ENV} ${AMPLIFY} ${PROVIDERS} ${CODEGEN} ${AWSCONFIG} ${CATEGORIES}
+fi

--- a/scripts/amplifyPush.sh
+++ b/scripts/amplifyPush.sh
@@ -63,6 +63,8 @@ while [[ $# -gt 0 ]];
 done
 set -- "${POSITIONAL[@]}"
 
+if [ -n "$AWS_BACKEND_ENVIRONMENT_ARN" ]; then ENV=${AWS_BACKEND_ENVIRONMENT_ARN##*/}; fi;
+
 # if no provided environment name, use default env variable, then user override
 if [[ ${ENV} = "" ]];
 then
@@ -129,12 +131,12 @@ fi
 if [[ ${IS_SIMPLE} ]];
 then
     echo "# Getting Amplify CLI Cloud-Formation stack info from environment cache"
-    STACKINFO="$(envCache --get stackinfo)"
+    STACKINFO="$(envCache --get stackInfo)"
     export STACKINFO
     init_env "${ENV}" "${AMPLIFY}" "${PROVIDERS}" "${CODEGEN}" "${AWSCONFIG}" "${CATEGORIES}"
     echo "# Store Amplify CLI Cloud-Formation stack info in environment cache"
     STACKINFO="$(amplify env get --json --name "${ENV}")"
-    envCache --set stackinfo "${STACKINFO}"
+    envCache --set stackInfo "${STACKINFO}"
     echo "STACKINFO=${STACKINFO}"
 else
     # old config file, above steps performed outside of this script

--- a/scripts/amplifyPush.sh
+++ b/scripts/amplifyPush.sh
@@ -129,12 +129,12 @@ fi
 if [[ ${IS_SIMPLE} ]];
 then
     echo "# Getting Amplify CLI Cloud-Formation stack info from environment cache"
-    STACKINFO="$(envCache --get stackInfo)"
+    STACKINFO="$(envCache --get stackinfo)"
     export STACKINFO
     init_env "${ENV}" "${AMPLIFY}" "${PROVIDERS}" "${CODEGEN}" "${AWSCONFIG}" "${CATEGORIES}"
     echo "# Store Amplify CLI Cloud-Formation stack info in environment cache"
     STACKINFO="$(amplify env get --json --name "${ENV}")"
-    envCache --set stackInfo "${STACKINFO}"
+    envCache --set stackinfo "${STACKINFO}"
     echo "STACKINFO=${STACKINFO}"
 else
     # old config file, above steps performed outside of this script

--- a/scripts/amplifyPush.sh
+++ b/scripts/amplifyPush.sh
@@ -21,7 +21,7 @@ init_env () {
     if [[ -z ${STACKINFO} ]];
     then
         echo "# Initializing new Amplify environment: ${ENV} (amplify init)"
-        [[ -z ${CATEGORIES} ]] && amplify init --amplify ${AMPLIFY} --providers ${PROVIDERS} --codegen ${CODEGEN} --yes || amplify init --amplify ${AMPLIFY} --providers ${PROVIDERS} --codegen ${CODEGEN} --categories ${CATEGORIES} --yes
+        [[ -z ${CATEGORIES} ]] && amplify init --amplify ${AMPLIFY} --providers ${PROVIDERS} --codegen ${CODEGEN} --yes --forcePush || amplify init --amplify ${AMPLIFY} --providers ${PROVIDERS} --codegen ${CODEGEN} --categories ${CATEGORIES} --yes --forcePush
         echo "# Environment ${ENV} details:"
         amplify env get --name ${ENV}
     else
@@ -29,7 +29,7 @@ init_env () {
         echo "# Importing Amplify environment: ${ENV} (amplify env import)"
         amplify env import --name ${ENV} --config "${STACKINFO}" --awsInfo ${AWSCONFIG} --yes;
         echo "# Initializing existing Amplify environment: ${ENV} (amplify init)"
-        [[ -z ${CATEGORIES} ]] && amplify init --amplify ${AMPLIFY} --providers ${PROVIDERS} --codegen ${CODEGEN} --yes || amplify init --amplify ${AMPLIFY} --providers ${PROVIDERS} --codegen ${CODEGEN} --categories ${CATEGORIES} --yes
+        [[ -z ${CATEGORIES} ]] && amplify init --amplify ${AMPLIFY} --providers ${PROVIDERS} --codegen ${CODEGEN} --yes --forcePush || amplify init --amplify ${AMPLIFY} --providers ${PROVIDERS} --codegen ${CODEGEN} --categories ${CATEGORIES} --yes --forcePush
         echo "# Environment ${ENV} details:"
         amplify env get --name ${ENV}
     fi
@@ -39,7 +39,7 @@ init_env () {
 ENV=""
 IS_SIMPLE=false
 POSITIONAL=()
-while [[ $# -gt 0 ]]
+while [[ $# -gt 0 ]];
     do
     key="$1"
     case ${key} in

--- a/scripts/amplifyPush.sh
+++ b/scripts/amplifyPush.sh
@@ -3,7 +3,7 @@ set -e
 IFS='|'
 
 help_output () {
-    echo "usage: amplify-push <--environment|-e <name>> <--simple|-s>"
+    echo "usage: $(basename "$0") <--environment|-e <name>> <--simple|-s>"
     echo "  --environment  The name of the Amplify environment to use"
     echo "  --simple  Optional simple flag auto-includes stack info from env cache"
     exit 1


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-hosting/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
This fixes the bash logic which would result in the init running more than once. I've seen plenty of confused people due to this subtle bash problem. See [SC2015](https://github.com/koalaman/shellcheck/wiki/SC2015) for the logical fallacy that the amplify init commands fall into. 

I also updated amplifyPush to reflect the latest version being used and fixed a few other potential sources of error.
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
likely fixes stuff like #2957, #2291, and #924
<!-- Also, please reference any associated PRs for documentation updates. -->

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
