### PR TITLE
Updated max build timeout value

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -79,7 +79,7 @@ backend:
 
 ### How do I override a build timeout?
 
-The default build timeout is 30 minutes. You can override the default build timeout using an environment variable: `_BUILD_TIMEOUT` (App settings > Environment variables). The minimum build timeout is 5 minutes. The maximum build timeout is 120 minutes.
+The default build timeout is 30 minutes. You can override the default build timeout using an environment variable: `_BUILD_TIMEOUT` (App settings > Environment variables). The minimum build timeout is 5 minutes. The maximum build timeout is 480 minutes i.e, 8 hours.
 
 ### How do I pull private packages during a build?
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-hosting/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

The maximum build timeout is 8 hours however, in the FAQ 120 minutes is mentioned.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
