### PR TITLE
Updated Convert an SSR App to SSG 

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -286,7 +286,7 @@ frontend:
   ...
 ```
 
-3. Update the build command in your package.json to use `next export`, then commit this to trigger a new non SSR build.
+3. Update the build command in your `next.config.js` to add `output: 'export'` inside the `nextConfig` (`v14.0.0`	**next export** has been **removed** in favor of **"output": "export"**), then commit this to trigger a new non SSR build.
 
 4. Finally, go to the `Rewrites and redirects` tab in the Amplify Hosting, and delete the first rewrite rule that was re-writing to your SSR CloudFront Distribution.
 


### PR DESCRIPTION
- NextJS from v13.3.0 next export already deprecated, and has been removed from version v14.0.0 and replace by "output" : "export", so for now if using the current document approach, it will causing error when building	 

#### Description of changes

- Removed next export (due to it **no longer support** by `NextJS` from `v13.3.0`, replace by `"output" : "export"` in the `next.config.js` 

Referring to the official document from [NextJS](https://nextjs.org/docs/pages/building-your-application/deploying/static-exports)

#### Issue #, if available

https://github.com/aws-amplify/amplify-hosting/issues/3920
https://github.com/aws-amplify/amplify-hosting/issues/3872
https://github.com/aws-amplify/amplify-hosting/issues/3869

and many more ...

#### Checklist

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
